### PR TITLE
Fix method RefineDetections in case of single detection

### DIFF
--- a/mask_rcnn_pytorch/detectionlayer.cpp
+++ b/mask_rcnn_pytorch/detectionlayer.cpp
@@ -76,6 +76,11 @@ at::Tensor RefineDetections(at::Tensor rois,
                   .to(at::dtype(at::kLong))
                   .squeeze();
 
+  // Unsqueeze in case keep is a 0-dimensional tensor
+  // otherwise calls like nms_class_ids.size(0) will fail
+  if (keep.ndimension() == 0)
+      keep = keep.unsqueeze(0);
+
   // Apply per-class NMS
   auto pre_nms_class_ids = class_ids.take(keep);
   auto pre_nms_scores = class_scores.take(keep);


### PR DESCRIPTION
This PR fixes an issue caused by the `squeezing` of the variable `keep` in method `RefineDetections()` within the C++ implementation of `Mask R-CNN`.

When the variable contains only one class id, the squeezing procedure transforms it to a 0-dimensional tensor, i.e. a scalar.

https://github.com/Kolkir/mlcpp/blob/989faf28c1d0f18c79e6433f3c70c67ac115b3bb/mask_rcnn_pytorch/detectionlayer.cpp#L74-L77

Once this happens, all the variables depending on `keep`, e.g. `pre_nms_class_ids`, are also transformed to scalars. As a consequence, any subsequent call to the method `size(dim)` on these tensors will fail with the error

```
Dimension specified as 0 but tensor has no dimensions
```

Currently, the above specified error is raised here

https://github.com/Kolkir/mlcpp/blob/989faf28c1d0f18c79e6433f3c70c67ac115b3bb/mask_rcnn_pytorch/nnutils.cpp#L79-L80

since `unique1d()` is called on `pre_nms_class_ids`

https://github.com/Kolkir/mlcpp/blob/989faf28c1d0f18c79e6433f3c70c67ac115b3bb/mask_rcnn_pytorch/detectionlayer.cpp#L84

One possible solution is to `unsqueeze` the vector if it is detected that is a 0-dimensional tensor as done in the present PR.
